### PR TITLE
Add Node 4.3.2 Version

### DIFF
--- a/4.3.2/Dockerfile
+++ b/4.3.2/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:4.3.2
+
+MAINTAINER Kamil Karczmarczyk <kkarczmarczyk@gmail.com>
+
+# Global install yarn package manager
+RUN apt-get update && apt-get install -y curl apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
+
+WORKDIR /workspace

--- a/4.3.2/slim/Dockerfile
+++ b/4.3.2/slim/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:4.3.2-slim
+
+MAINTAINER Kamil Karczmarczyk <kkarczmarczyk@gmail.com>
+
+# Global install yarn package manager
+RUN apt-get update && apt-get install -y curl apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
+    
+WORKDIR /workspace

--- a/4.3.2/wheezy/Dockerfile
+++ b/4.3.2/wheezy/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:4.3.2-wheezy
+
+MAINTAINER Kamil Karczmarczyk <kkarczmarczyk@gmail.com>
+
+# Global install yarn package manager
+RUN npm set progress=false && \
+    npm install -g --progress=false yarn
+
+WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Node docker image with yarn package manager ( http://yarnpkg.com )
 ## Supported tags and respective `Dockerfile` links
 
 -       [`latest` (*latest/Dockerfile*)](https://github.com/kkarczmarczyk/docker-node-yarn/blob/master/latest/Dockerfile)
+-       [`4.3.2`, (*4.3.2/Dockerfile*)](https://github.com/kkarczmarczyk/docker-node-yarn/blob/master/4.3.2/Dockerfile) (Version used by AWS Lambda)
+-       [`4.3.2-slim`, (*4.3.2/Dockerfile*)](https://github.com/kkarczmarczyk/docker-node-yarn/blob/master/4.3.2/slim/Dockerfile) (Version used by AWS Lambda)
+-       [`4.3.2-wheezy`, (*4.3.2/Dockerfile*)](https://github.com/kkarczmarczyk/docker-node-yarn/blob/master/4.3.2/wheezy/Dockerfile) (Version used by AWS Lambda)
 -       [`4.6`, (*4.6/Dockerfile*)](https://github.com/kkarczmarczyk/docker-node-yarn/blob/master/4.6/Dockerfile)
 -       [`4.6-slim`, (*4.6/slim/Dockerfile*)](https://github.com/kkarczmarczyk/docker-node-yarn/blob/master/4.6/slim/Dockerfile)
 -       [`4.6-wheezy`, (*4.6/wheezy/Dockerfile*)](https://github.com/kkarczmarczyk/docker-node-yarn/blob/master/4.6/wheezy/Dockerfile)


### PR DESCRIPTION
AWS Lambda only supports (presently) Node 4.3.2. Although this will not replicate a Lambda environment completely, it will provide developers with a container that is node version consistent.

Note that I've also used the suggestion in #6. Assuming, you're ok with this pull request's approach, I'd be happy to submit a separate PR updating the other versions to use this approach.