### PR TITLE
Install yarn via apt-get instead of npm install

### DIFF
--- a/4.6/Dockerfile
+++ b/4.6/Dockerfile
@@ -3,7 +3,9 @@ FROM node:4.6
 MAINTAINER Kamil Karczmarczyk <kkarczmarczyk@gmail.com>
 
 # Global install yarn package manager
-RUN npm set progress=false && \
-    npm install -g --progress=false yarn
+RUN apt-get update && apt-get install -y curl apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
 
 WORKDIR /workspace

--- a/4.6/slim/Dockerfile
+++ b/4.6/slim/Dockerfile
@@ -3,7 +3,9 @@ FROM node:4.6-slim
 MAINTAINER Kamil Karczmarczyk <kkarczmarczyk@gmail.com>
 
 # Global install yarn package manager
-RUN npm set progress=false && \
-    npm install -g --progress=false yarn
+RUN apt-get update && apt-get install -y curl apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
 
 WORKDIR /workspace

--- a/4.6/wheezy/Dockerfile
+++ b/4.6/wheezy/Dockerfile
@@ -3,7 +3,9 @@ FROM node:4.6-wheezy
 MAINTAINER Kamil Karczmarczyk <kkarczmarczyk@gmail.com>
 
 # Global install yarn package manager
-RUN npm set progress=false && \
-    npm install -g --progress=false yarn
+RUN apt-get update && apt-get install -y curl apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
 
 WORKDIR /workspace

--- a/6.9/Dockerfile
+++ b/6.9/Dockerfile
@@ -3,7 +3,9 @@ FROM node:6.9
 MAINTAINER Kamil Karczmarczyk <kkarczmarczyk@gmail.com>
 
 # Global install yarn package manager
-RUN npm set progress=false && \
-    npm install -g --progress=false yarn
+RUN apt-get update && apt-get install -y curl apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
 
 WORKDIR /workspace

--- a/6.9/slim/Dockerfile
+++ b/6.9/slim/Dockerfile
@@ -3,7 +3,9 @@ FROM node:6.9-slim
 MAINTAINER Kamil Karczmarczyk <kkarczmarczyk@gmail.com>
 
 # Global install yarn package manager
-RUN npm set progress=false && \
-    npm install -g --progress=false yarn
+RUN apt-get update && apt-get install -y curl apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
 
 WORKDIR /workspace

--- a/6.9/wheezy/Dockerfile
+++ b/6.9/wheezy/Dockerfile
@@ -3,7 +3,9 @@ FROM node:6.9-wheezy
 MAINTAINER Kamil Karczmarczyk <kkarczmarczyk@gmail.com>
 
 # Global install yarn package manager
-RUN npm set progress=false && \
-    npm install -g --progress=false yarn
+RUN apt-get update && apt-get install -y curl apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
 
 WORKDIR /workspace

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -2,8 +2,9 @@ FROM node:7.4
 
 MAINTAINER Kamil Karczmarczyk <kkarczmarczyk@gmail.com>
 
-# Global install yarn package manager
-RUN npm set progress=false && \
-    npm install -g --progress=false yarn
+RUN apt-get update && apt-get install -y curl apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
 
 WORKDIR /workspace

--- a/7.4/slim/Dockerfile
+++ b/7.4/slim/Dockerfile
@@ -3,7 +3,9 @@ FROM node:7.4-slim
 MAINTAINER Kamil Karczmarczyk <kkarczmarczyk@gmail.com>
 
 # Global install yarn package manager
-RUN npm set progress=false && \
-    npm install -g --progress=false yarn
+RUN apt-get update && apt-get install -y curl apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
 
 WORKDIR /workspace

--- a/7.4/wheezy/Dockerfile
+++ b/7.4/wheezy/Dockerfile
@@ -3,7 +3,9 @@ FROM node:7.4-wheezy
 MAINTAINER Kamil Karczmarczyk <kkarczmarczyk@gmail.com>
 
 # Global install yarn package manager
-RUN npm set progress=false && \
-    npm install -g --progress=false yarn
+RUN apt-get update && apt-get install -y curl apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
 
 WORKDIR /workspace

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -3,7 +3,9 @@ FROM node:latest
 MAINTAINER Kamil Karczmarczyk <kkarczmarczyk@gmail.com>
 
 # Global install yarn package manager
-RUN npm set progress=false && \
-    npm install -g --progress=false yarn
+RUN apt-get update && apt-get install -y curl apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn
 
 WORKDIR /workspace


### PR DESCRIPTION
For all versions except 4.3.2 (which is already updated), change installation of Yarn to be via apt-get instead of npm install. This is recommended in the [yarn docs](https://yarnpkg.com/en/docs/install#alternatives-tab)

Resolves #6 